### PR TITLE
Update ercf.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ I love my ERCF and building it was the most fun I've had in many years of the 3D
 <li>Support all options for both toolhead sensor based loading/unloading and the newer sensorless filament homing (no toolhead sensor)
 <li>Supports sync load and unloading steps moving the extruder and gear motor together, including a config with toolhead sensor that can work with FLEX materials!
   <li>Fully implements “EndlessSpool” with new concept of Tool --> Gate mapping.  This allows empty gates to be identified and tool changes subsequent to runout to use the correct filament spool.  It has the added advantage for being able to map gates to tools in case of slicing to spool loading mismatch.
-<li>Vastely imporved logging including a new log to file functionality. You can keep the console log to a minimum and send debugging information to `ercf.log` located in the same directory as Klipper logs
+<li>Vastly improved logging including a new log to file functionality. You can keep the console log to a minimum and send debugging information to `ercf.log` located in the same directory as Klipper logs
 <li>Optional fun visual representation of loading and unloading sequence
 <li>Ability to specify empty or disabled tools (gates).
 <li>Formal support for the filament bypass block with associated new commands and state if using it.
@@ -20,7 +20,7 @@ I love my ERCF and building it was the most fun I've had in many years of the 3D
 <ul>
 <li>Reworks calibration routine to average measurements, add compensation based on spring in filament (related to ID and length of bowden), and considers configuration options.
 <li>Runtime configuration via new command (ERCF_TEST_CONFIG) for most options which avoids constantly restarting klipper or recalibrating during setup
-<li>Workarond to some of the ways to provoke Klipper “Timer too close” errors (although there are definitely bugs in the Klipper firmware)
+<li>Workaround to some of the ways to provoke Klipper “Timer too close” errors (although there are definitely bugs in the Klipper firmware)
 <li>Measures “spring” in filament after extruder homing for more accurate calibration reference
 <li>Adds servo_up delay making the gear to extruder transition of filament more reliable (maintains pressure)
 <li>New "TEST" commands to help diagnose issues with encoder
@@ -72,7 +72,7 @@ Also be sure to read my [notes on Encoder problems](doc/ENCODER.md) - the better
 <li> v1.1.2 - Improved install.sh -i to include servo and calib bowden length; Better detection of malfunctioning toolhead sensor
 <li> v1.1.3 - Added ERCF_RECOVER command to re-establish filament position after manual intervention and filament movement. Not necessary if you use ERCF commands to correct problem but useful to call prior to RESUME; Much improved install.sh to cover toolhead sensor and auto restart moonraker on first time install
 <li> v1.1.4 - Change to automatic clog detection length based on community feedback
-<li> v1.1.5 - Further install.sh improvements - no longer need filament_sensor defined or duplicate pin override if not using clog detection; Cleaned up documentation in template config file; Stallguard filament homing should now be possible (have to configure by hand); Additional configuration checks on startup; minor useabilty improvements based on community feedback
+<li> v1.1.5 - Further install.sh improvements - no longer need filament_sensor defined or duplicate pin override if not using clog detection; Cleaned up documentation in template config file; Stallguard filament homing should now be possible (have to configure by hand); Additional configuration checks on startup; minor useability improvements based on community feedback
 <li> v1.1.6 - New feature to log to file independently to console (allows for clean console and debug to logfile);  New gate statistics (like slippage) are recorded and available with an augmented ERCF_DUMP_STATS command; Several minor improvements and fixes suggested by community
 <li> v1.1.7 - No need to put anything ERCF related into existing macros (START/PAUSE/RESUME/STOP/CANCEL) anymore!;  Improvements to install script for non EASY-BRD config; Exposed all built-in gear/extruder feed speeds; Tweaks to tolerance checks to prevent false pauses; No annoying pause/unlock sequence while you are playing out of a print
 </ul>
@@ -82,7 +82,7 @@ Also be sure to read my [notes on Encoder problems](doc/ENCODER.md) - the better
 ## Summary of new commands:
   | Commmand | Description | Parameters |
   | -------- | ----------- | ---------- |
-  | ERCF_STATUS | Report on ERCF state, cababilities and Tool-to-Gate map | SHOWCONFIG=\[0\|1\] Whether or not to describe the machine configuration in status message |
+  | ERCF_STATUS | Report on ERCF state, capabilities and Tool-to-Gate map | SHOWCONFIG=\[0\|1\] Whether or not to describe the machine configuration in status message |
   | ERCF_TEST_CONFIG | Dump / Change essential load/unload config options at runtime | Many. Best to run ERCF_TEST_CONFIG without options to report all parameters that can be specified |
   | ERCF_DISPLAY_TTG_MAP | Displays the current Tool - to - Gate mapping (can be used all the time but generally designed for EndlessSpool  | None |
   | ERCF_REMAP_TTG | Reconfiguration of the Tool - to - Gate (TTG) map.  Can also set gates as empty! | TOOL=\[0..n\] <br>GATE=\[0..n\] Maps specified tool to this gate (multiple tools can point to same gate) <br>AVAILABLE=\[0\|1\]  Marks gate as available or empty |
@@ -90,8 +90,8 @@ Also be sure to read my [notes on Encoder problems](doc/ENCODER.md) - the better
   | ERCF_LOAD_BYPASS | Does the extruder loading part of the load sequence - designed for bypass filament loading | None |
   | ERCF_TEST_HOME_TO_EXTRUDER | For calibrating extruder homing - TMC current setting, etc. | RETURN=\[0\|1\] Whether to return the filament to the approximate starting position after homing - good for repeated testing |
   | ERCF_TEST_TRACKING | Simple visual test to see how encoder tracks with gear motor | DIRECTION=\[-1\|1\] Direction to perform the test <br>STEP=\[0.5..20\] Size of individual steps<br>Defaults to load direction and 1mm step size |
-  | ERCF_PRELOAD | Helper for filament loading. Feed filament into gate, ERCF will catch it and correctly positin at the specified gate | GATE=\[0..n\] The specific gate to preload. If ommitted the currently selected gate can be loaded |
-  | ERCF_CHECK_GATES | Inspect the gate(s) and mark availability | GATE=\[0..n\] The specific gate to check. If ommitted all gates will be checked (the default) |
+  | ERCF_PRELOAD | Helper for filament loading. Feed filament into gate, ERCF will catch it and correctly position at the specified gate | GATE=\[0..n\] The specific gate to preload. If omitted the currently selected gate can be loaded |
+  | ERCF_CHECK_GATES | Inspect the gate(s) and mark availability | GATE=\[0..n\] The specific gate to check. If omitted all gates will be checked (the default) |
   | ERCF_RECOVER | Recover filament position. Useful to call prior to RESUME if you intervene/manipulate filament by hand | None |
   
   Note that some existing commands have been enhanced a little.  See the [command reference](#ercf-command-reference) at the end of this page.
@@ -100,7 +100,7 @@ Also be sure to read my [notes on Encoder problems](doc/ENCODER.md) - the better
 
 ## New features in detail:
 ### Config Loading and Unload sequences explained
-Note that if a toolhead sensor is configured it will become the default filament homing method and home to extruder an optional but unecessary step. Also note the home to extruder step will always be performed during calibration of tool 0 (to accurately set `ercf_calib_ref`). For accurate homing and to avoid grinding, tune the gear stepper current reduction `extruder_homing_current` as a % of the default run current.
+Note that if a toolhead sensor is configured it will become the default filament homing method and home to extruder an optional but unnecessary step. Also note the home to extruder step will always be performed during calibration of tool 0 (to accurately set `ercf_calib_ref`). For accurate homing and to avoid grinding, tune the gear stepper current reduction `extruder_homing_current` as a % of the default run current.
 
 #### Understanding the load sequence:
     1. ERCF [T1] >.... [encoder] .............. [extruder] .... [sensor] .... [nozzle] UNLOADED (@0.0 mm)
@@ -113,12 +113,12 @@ Note that if a toolhead sensor is configured it will become the default filament
 The "visual log" above shows individual steps of the loading process:
   <ol>
     <li>Starting with filament unloaded and sitting in the gate for tool 1
-    <li>Firstly ERCF clamps the servo down and pulls a short length of filament through the encoder. It it doesn't see filament it will try a second time. If still no filamament it will report the error. The speed of this initial movement is controlled by 'short_moves_speed', the accelaration is as defined on the gear stepper motor config in 'ercf_hardware.cfg'
+    <li>Firstly ERCF clamps the servo down and pulls a short length of filament through the encoder. It it doesn't see filament it will try a second time. If still no filament it will report the error. The speed of this initial movement is controlled by 'short_moves_speed', the acceleration is as defined on the gear stepper motor config in 'ercf_hardware.cfg'
     <li>ERCF will then load the filament through the bowden in a fast movement.  The speed is controlled by 'long_moves_speed'.  This movement can be broken up into multiple movements with 'num_moves' to overcome "Timer too close" errors from Klipper. If you keep your step size to 8 for the gear motor you are likely to be able to operate with a single fast movement.  The length of this movement is set when you calibrate ERCF and stored in 'ercf_vars.cfg'.  There is an advanced option to allow for correction of this move if slippage is detected controlled by 'apply_bowden_correction' and 'load_bowden_tolerance' (see comments in 'ercf_parameters.cfg' for more details)
     <li>The example shown uses a toolhead sensor, but if you configure sensorless filament homing then ERCF will now creep towards your extruder gears to detect this point as its homing position.  This homing move is controlled by 'extruder_homing_max' (maximum distance to advance in order to attempt to home the extruder), 'extruder_homing_step' (step size to use when homing to the extruder with collision detection), 'extruder_homing_current' (tunable to control how much % to temporarily reduce the gear stepper current to prevent grinding of filament)
-    <li>This is the move into the toolhead and is the most critical transistion point.  ERCF will advance the extruder looking to see that the filament was sucessfully picked up. In the case of a toolhead sensor this is deterministic because it will advance to the sensor and use this as a new homing point.  For sensorless ERCF will look for encoder movement implying that filament has been picked up.  Optionally this move can be made to run gear and extruder motors synchronously for greater reliability. 'sync_load_length' (mm of synchronized extruder loading at entry to extruder).  If synchronous load is not employed ERCF will attempt to use the "spring" in the filament by delaying the servo release by 'delay_servo_release' mm.
+    <li>This is the move into the toolhead and is the most critical transition point.  ERCF will advance the extruder looking to see that the filament was successfully picked up. In the case of a toolhead sensor this is deterministic because it will advance to the sensor and use this as a new homing point.  For sensorless ERCF will look for encoder movement implying that filament has been picked up.  Optionally this move can be made to run gear and extruder motors synchronously for greater reliability. 'sync_load_length' (mm of synchronized extruder loading at entry to extruder).  If synchronous load is not employed ERCF will attempt to use the "spring" in the filament by delaying the servo release by 'delay_servo_release' mm.
 <br>
-With toolhead sensor enabled there is a little more to this step: ERCF will home the end of the filament to the toolhead sensor controled by 'toolhead_homing_max' (maximum distance to advance in order to attempt to home to toolhead sensor) and 'toolhead_homing_step (step size to use when homing to the toolhead sensor. If 'sync_load_length' is greater than 0 this homing step will be synchronised.
+With toolhead sensor enabled there is a little more to this step: ERCF will home the end of the filament to the toolhead sensor controlled by 'toolhead_homing_max' (maximum distance to advance in order to attempt to home to toolhead sensor) and 'toolhead_homing_step (step size to use when homing to the toolhead sensor. If 'sync_load_length' is greater than 0 this homing step will be synchronised.
 <br>The speed of all movements in this step is controlled by 'sync_load_speed'
     <li>Now the filament is under exclusive control of the extruder.  Filament is moved the remaining distance to the meltzone. This distance is defined by 'home_position_to_nozzle' and is either the distance from the toolhead sensor to the nozzle or the distance from the extruder gears to the nozzle depending on your setup.  This move speed is controlled by 'nozzle_load_speed'.  We are now loaded and ready to print.
   </ol>
@@ -134,16 +134,16 @@ With toolhead sensor enabled there is a little more to this step: ERCF will home
   
 The "visual log" above shows individual steps of the loading process:
   <ol>
-    <li>Starting with filament loaded in tool 1. This example is taken from an unload that is not under control of the slicer, so the first thing that happends is that a tip is formed on the end of the filament which ends with filament in the cooling zone of the extruder. This operation is controlled but the user edited '_ERCF_FORM_TIP_STANDALONE' macro in 'ercf_software.cfg'
+    <li>Starting with filament loaded in tool 1. This example is taken from an unload that is not under control of the slicer, so the first thing that happens is that a tip is formed on the end of the filament which ends with filament in the cooling zone of the extruder. This operation is controlled but the user edited '_ERCF_FORM_TIP_STANDALONE' macro in 'ercf_software.cfg'
     <li>This step only occurs with toolhead sensor. The filament is withdrawn until it no longer detected by toolhead sensor. This is done at the 'nozzle_unload_speed' and provides a more accurate determination of how much further to retract and a safety check that the filament is not stuck in the nozzle
-    <li>ERCF then moves the filament out of the extruder at 'nozzle_unload_speed'. Once at where it believes is the gear entrance to the extruder an optional short synchronized (gear and extruder) move can be configured. This is contolled by 'sync_unload_speed' and 'sync_unload_length'.  This is a great saftely step and "hair pull" operation but also serves to ensure that the ERCF gear has a grip on the filament.  If synchronized unload is not configured ERCF will still perform an initial short move with gear motor, again to ensure filament is gripped
-    <li>The filamemnt is now extracted quickly through the bowden. The speed is controlled by 'long_moves_speed' and the movement can be broken up with 'num_moves' similar to when loading. Apply bowden correction can siimilarly be employed to correct for slippage
+    <li>ERCF then moves the filament out of the extruder at 'nozzle_unload_speed'. Once at where it believes is the gear entrance to the extruder an optional short synchronized (gear and extruder) move can be configured. This is controlled by 'sync_unload_speed' and 'sync_unload_length'.  This is a great safely step and "hair pull" operation but also serves to ensure that the ERCF gear has a grip on the filament.  If synchronized unload is not configured ERCF will still perform an initial short move with gear motor, again to ensure filament is gripped
+    <li>The filament is now extracted quickly through the bowden. The speed is controlled by 'long_moves_speed' and the movement can be broken up with 'num_moves' similar to when loading. Apply bowden correction can similarly be employed to correct for slippage
     <li>Completion of the the fast bowden move
     <li>At this point ERCF performs a series of short moves looking for when the filament exits the encoder.  The speed is controlled by 'short_moves_speed'
     <li>When the filament is released from the encoder, the remainder of the distance to the park position is moved at 'short_moves_speed'.  The filament is now unloaded.
   </ol>
 
-When the state of ERCF is unkown, ERCF will perform other movements and look at its sensores to try to assertain filament location. This may modify the above sequence and result in the ommission of the fast bowden move.
+When the state of ERCF is unknown, ERCF will perform other movements and look at its sensors to try to ascertain filament location. This may modify the above sequence and result in the omission of the fast bowden move.
 
 #### Possible loading options (explained in ercf_parameters.cfg template):
      If you have a toolhead sensor for filament homing:
@@ -181,7 +181,7 @@ When the state of ERCF is unkown, ERCF will perform other movements and look at 
   
   **Advanced options**
 When not using synchronous load move the spring tension in the filament held by servo will be leverage to help feed the filament into the extruder. This is controlled with the `delay_servo_release` setting. It defaults to 2mm and is unlikely that it will need to be altered.
-<br>An option to home to the extruder using stallguard `homing_method=1` is avaiable but not recommended: (i) it is not necessary with current reduction, (ii) it is not readily compatible with EASY-BRD and (iii) is currently incompatible with sensorless selector homing which hijacks the gear endstop configuration.
+<br>An option to home to the extruder using stallguard `homing_method=1` is available but not recommended: (i) it is not necessary with current reduction, (ii) it is not readily compatible with EASY-BRD and (iii) is currently incompatible with sensorless selector homing which hijacks the gear endstop configuration.
 <br>The 'apply_bowden_correction' setting, if enabled, will make the driver "believe" the encoder reading and make correction moves to bring the filament to the desired end of bowden position. This is useful is you suspect slippage on high speed loading, perhaps when yanking on spool (requires accurate encoder). If disabled, the gear stepper will be solely responsible for filament positioning in bowden (requires minimal friction in feeder tubes). The associated (advanced) 'load_bowden_tolerance' defines the point at which to apply to correction moves. See 'ercf_parameters.cfg' for more details.
   
   **Note about post homing distance**
@@ -192,14 +192,14 @@ This is much simplier than loading. The toolhead sensor, if installed, will auto
 `sync_unload_length` controls the mm of synchronized movement at start of bowden unloading.  This can make unloading more reliable if the tip is caught in the gears and will act as what Ette refers to as a "hair pulling" step on unload.  This is an optional step, set to 0 to disable.
 
 ### Tool-to-Gate (TTG) mapping and EndlessSpool application
-When changing a tool with the `Tx` command the ERCF will by default select the filament at the gate (spool) of the same number.  The mapping built into this *Happy Hare* driver allows you to modify that.  There are 3 primarly use cases for this feature:
+When changing a tool with the `Tx` command the ERCF will by default select the filament at the gate (spool) of the same number.  The mapping built into this *Happy Hare* driver allows you to modify that.  There are 3 primary use cases for this feature:
 <ol>
   <li>You have loaded your filaments differently than you sliced gcode file... No problem, just issue the appropriate remapping commands prior to printing
   <li>Some of "tools" don't have filament and you want to mark them as empty to avoid selection.
-  <li>Most importantly, for EndlessSpool - when a filament runs out on one gate (spool) then next in the sequence is automatically mapped to the original tool.  It will therefore continue to print on subsequent tool changes.  You can also replace the spool and update the map to indicate avaiablity mid print
+  <li>Most importantly, for EndlessSpool - when a filament runs out on one gate (spool) then next in the sequence is automatically mapped to the original tool.  It will therefore continue to print on subsequent tool changes.  You can also replace the spool and update the map to indicate availability mid print
 </ol>
 
-*Note that the initial availability of filament at each gate can also be specfied in the `ercf_parameters.cfg` file by updating the `gate_status` list. E.g.
+*Note that the initial availability of filament at each gate can also be specified in the `ercf_parameters.cfg` file by updating the `gate_status` list. E.g.
 >gate_status = 1, 1, 0, 0, 1, 0, 0, 0, 1
 
   on a 9-gate ERCF would mark gates 2, 3, 5, 6 & 7 as empty
@@ -213,7 +213,7 @@ To view the current mapping you can use either `ERCF_STATUS` or `ERCF_DISPLAY_TT
 Since EndlessSpool is not something that triggers very often you can use the following to simulate the action:
   > ERCF_ENCODER_RUNOUT RUNOUT=1
 
-This will emulate a filament runout and force ERCF to interpret it as a true runout and not a possbile clog. ERCF will then run the following sequence:
+This will emulate a filament runout and force ERCF to interpret it as a true runout and not a possible clog. ERCF will then run the following sequence:
 <ul>
   <li>Move the toolhead up a little (defined by 'z_hop_distance & z_hop_speed') to avoid blobs
   <li>Call '_ERCF_ENDLESS_SPOOL_PRE_UNLOAD' macro.  Typically this where you would quickly move the toolhead to your parking area
@@ -222,7 +222,7 @@ This will emulate a filament runout and force ERCF to interpret it as a true run
   <li>Move the toolhead back down the final amount and resume the print
 </ul>
 
-The default supplied _PRE and _POST macros call PAUSE/RESUME which is typically a simlar operation and may be already sufficent. Note: A common problem is that a custom _POST macro does not return the toolhead to previous position.  ERCF will still handle this case but it will move very slowly because it is not expecting large horizontal movement.
+The default supplied _PRE and _POST macros call PAUSE/RESUME which is typically a similar operation and may be already sufficient. Note: A common problem is that a custom _POST macro does not return the toolhead to previous position.  ERCF will still handle this case but it will move very slowly because it is not expecting large horizontal movement.
 
 <br>
   
@@ -237,7 +237,7 @@ The default supplied _PRE and _POST macros call PAUSE/RESUME which is typically 
 If you have installed the optional filament bypass block your can configure its selector position by setting `bypass_selector` in `ercf_parameters.cfg`. Once this is done you can use the following command to unload any ERCF controlled filament and select the bypass:
   > ERCF_SELECT_BYPASS
   
-  Once you have filament loaded upto the extruder you can load the filament to nozzle with
+  Once you have filament loaded up to the extruder you can load the filament to nozzle with
   > ERCF_LOAD_BYPASS
 
 ### Adjusting configuration at runtime
@@ -245,13 +245,13 @@ If you have installed the optional filament bypass block your can configure its 
   
   <img src="doc/ercf_test_config.png" width="500" alt="ERCF_TEST_CONFIG">
   
-  Any of the displayed config settings can be modifed.  E.g.
+  Any of the displayed config settings can be modified.  E.g.
   > ERCF_TEST_CONFIG home_position_to_nozzle=45
   
-  Will update the distance from homing postion to nozzle.  The change is designed for testing was will not be persistent.  Once you find your tuned settings be sure to update `ercf_parameters.cfg`
+  Will update the distance from homing position to nozzle.  The change is designed for testing was will not be persistent.  Once you find your tuned settings be sure to update `ercf_parameters.cfg`
 
 ### Updated Calibration Ref
-  Setting the `ercf_calib_ref` is slightly different in that it will, by default, average 3 runs and compsensate for spring tension in filament held by servo. It might be worth limiting to a single pass until you have tuned the gear motor current. Here is an example:
+  Setting the `ercf_calib_ref` is slightly different in that it will, by default, average 3 runs and compensate for spring tension in filament held by servo. It might be worth limiting to a single pass until you have tuned the gear motor current. Here is an example:
   
   <img src="doc/Calibration Ref.png" width="500" alt="ERCF_CALIBRATION_SINGLE TOOL=0">
   
@@ -277,7 +277,7 @@ There are four configuration options that control logging:
 The logfile will be placed in the same directory as other log files and is called `ercf.log`.  It will rotate and keep the last 5 versions (just like klipper).  The default log level for ercf.log is "3" but can be set by adding `logfile_level` in you `ercf_parameters.cfg`.  With this available my suggestion is to reset the console logging level `log_level: 1` for an uncluttered experience knowing that you can always access `ercf.log` for debugging at a later time.  Oh, and if you don't want the logfile, no problem, just set `logfile_level: -1`
 
 ### Pause / Resume / Cancel_Print macros:
-It is no longer necessary to added anything to these macros -- ERCF will automatically wrap anything defined.   If you have used other versions of the software then you should remove these customizations. To understand the philosphy and expectations here is the sequence:
+It is no longer necessary to added anything to these macros -- ERCF will automatically wrap anything defined.   If you have used other versions of the software then you should remove these customizations. To understand the philosophy and expectations here is the sequence:
 <br>
   
 During a print, if ERCF detects a problem, it will record the print position, safely lift the nozzle up to `z_hop_height` at `z_hop_speed` (to prevent a blob).  It will then call the user's PAUSE macro (which can be the example one supplied in `ercf_software.cfg`).  It is expected that pause will save it's starting position (GCODE_SAVE_STATE) and move the toolhead to a park area, often above a purge bucket, at fast speed.
@@ -289,10 +289,10 @@ The user then calls 'ERCF_UNLOCK', addresses the issue and called 'RESUME'
 The user's RESUME macro may do some purging or nozzle cleaning, but is expected to return the toolhead at higher speed to where it was left when the pause macro was called.  At this point the ERCF wrapper takes over and is responsible for dropping the toolhead back down to the print and resumes printing.
 <br>
   
-ERCF will allways return the toolhead to the correct position, but if you leave it in your park area will will move it back very slowly.  You can to follow the above sequence to make this operation fast to prevent oozing from leaking on your print. 
+ERCF will always return the toolhead to the correct position, but if you leave it in your park area will will move it back very slowly.  You can to follow the above sequence to make this operation fast to prevent oozing from leaking on your print. 
 
 ## My Testing:
-  This software is largely rewritten as well as being extended and so, despite best efforts, has probably introducted some bugs that may not exist in the official driver.  It also lacks extensive testing on different configurations that will stress the corner cases.  I have been using successfully on Voron 2.4 / ERCF with EASY-BRD.  I use a self-modified CW2 extruder with foolproof microswitch toolhead sensor. My day-to-day configuration is to load the filament to the extruder in a single movement (`num_moves=1`) at 200mm/s, then home to toolhead sensor with synchronous gear/extruder movement (option #1 explained above).  I use the sensorless selector and have runout and EndlessSpool enabled.
+  This software is largely rewritten as well as being extended and so, despite best efforts, has probably introduced some bugs that may not exist in the official driver.  It also lacks extensive testing on different configurations that will stress the corner cases.  I have been using successfully on Voron 2.4 / ERCF with EASY-BRD.  I use a self-modified CW2 extruder with foolproof microswitch toolhead sensor. My day-to-day configuration is to load the filament to the extruder in a single movement (`num_moves=1`) at 200mm/s, then home to toolhead sensor with synchronous gear/extruder movement (option #1 explained above).  I use the sensorless selector and have runout and EndlessSpool enabled.
 
 ### My Setup:
 <img src="doc/My Voron 2.4 and ERCF.jpg" width="400" alt="My Setup">
@@ -305,9 +305,9 @@ Firstly the importance of a reliable and fairly accurate encoder should not be u
   <li>Eliminate all points of friction in the filament path.  There is lots written about this already but I found some unusual places where filament was rubbing on plastic and drilling out the path improved things a good deal.
   <li>This version of the driver software both, compensates for, and exploits the spring that is inherently built when homing to the extruder.  The `ERCF_CALIBRATE_SINGLE TOOL=0` (which calibrates the *ercf_calib_ref* length) averages the measurement of multiple passes, measures the spring rebound and considers the configuration options when recommending and setting the ercf_calib_ref length.  If you change basic configuration options it is advisable to rerun this calibration step again.
   <li>The dreaded "Timer too close" can occur but I believe I have worked around most of these cases.  The problem is not always an overloaded mcu as often cited -- there are a couple of bugs in Klipper that will delay messages between mcu and host and thus provoke this problem.  To minimize you hitting these, I recommend you use a step size of 8 for the gear motor. You don't need high fidelity and this greatly reduces the chance of this error. Also, increasing 'num_moves' also is a workaround.  I'm not experiencing this and have a high speed (200 mm/s) single move load with a step size of 8.
-  <li>The servo problem where a servo with move to end position and then jump back can occur due to bug in Klipper just like the original software but also because of power supply problems. The workaroud for the former is increase the same servo "dwell" config options in small increments until the servo works reliably. Note that this driver will retry the initial servo down movement if it detects slippage thus working around this issue to some extent.
+  <li>The servo problem where a servo with move to end position and then jump back can occur due to bug in Klipper just like the original software but also because of power supply problems. The workaround for the former is increase the same servo "dwell" config options in small increments until the servo works reliably. Note that this driver will retry the initial servo down movement if it detects slippage thus working around this issue to some extent.
   <li>I also added a 'apply_bowden_correction' config option that dictates whether the driver "believes" the encoder or not for long moves.  If enabled, the driver will make correction moves to get the encoder reading correct.  If disabled the gear stepper movement will be applied without slippage detection.  Details on when this is useful is documented in 'ercf_parameters'.  If enabled, the options 'load_bowden_tolerance' and 'unload_bowden_tolerance' will set the threshold at which correction is applied.
-  <li>I can recommend the "sensorless selector" option -- it works well and provides for additional recovery abilities if filment gets stuck in encoder preventing selection of a different gate.
+  <li>I can recommend the "sensorless selector" option -- it works well and provides for additional recovery abilities if filament gets stuck in encoder preventing selection of a different gate.
   <li>Speeds.... starting in v1.1.7 the speed setting for all the various moves made by ERCF can be tuned.  These are all configurable in the 'ercf_parameters.cfg' file or can be tested without restarting Klipper with the 'ERCF_TEST_CONFIG' command.  If you want to optimise performance you might want to tuning these faster.  If you do, watch for the gear stepper missing steps which will often be reported as slippage.
 </ul>
 
@@ -321,17 +321,17 @@ Good luck and hopefully a little less *enraged* printing.  You can find me on di
   *Note that some of these commands have been enhanced from the original*
 
   ## Logging and Stats
-  | Commmand | Description | Parameters |
+  | Command | Description | Parameters |
   | -------- | ----------- | ---------- |
   | ERCF_RESET_STATS | Reset the ERCF statistics | None |
   | ERCF_DUMP_STATS | Dump the ERCF statistics (and Gate statistics to debug level - usually the logfile) | None |
   | ERCF_SET_LOG_LEVEL | Sets the logging level and turning on/off of visual loading/unloading sequence and stats reporting | LEVEL=\[1..4\] The level of logging to the console (1 recommended)<br>LOGFILE=\[1..4\] The level of logging to the ercf.log file (3 recommended)<br>VISUAL=\[0\|1\] Whether to also show visual representation<br>STATS=\[0\|1\] Whether to log print stats and gate summary on every tool change |
-  | ERCF_STATUS | Report on ERCF state, cababilities and Tool-to-Gate map | SHOWCONFIG=\[0\|1\] Whether or not to describe the machine configuration in status message |
+  | ERCF_STATUS | Report on ERCF state, capabilities and Tool-to-Gate map | SHOWCONFIG=\[0\|1\] Whether or not to describe the machine configuration in status message |
   | ERCF_DISPLAY_ENCODER_POS | Displays the current value of the ERCF encoder | None |
   <br>
 
   ## Calibration
-  | Commmand | Description | Parameters |
+  | Command | Description | Parameters |
   | -------- | ----------- | ---------- |
   | ERCF_CALIBRATE | Complete calibration of all ERCF tools | None |
   | ERCF_CALIBRATE_SINGLE | Calibration of a single ERCF tool | TOOL=\[0..n\] <br>REPEATS=\[1..10\] How many times to repeat the calibration for reference tool T0 (ercf_calib_ref) <br>VALIDATE=\[0\|1\] If True then calibration of tool 0 will simply verify the ratio i.e. another check of encoder accuracy (should result in a ratio of 1.0) |
@@ -340,18 +340,18 @@ Good luck and hopefully a little less *enraged* printing.  You can find me on di
   <br>
 
   ## Servo and motor control
-  | Commmand | Description | Parameters |
+  | Command | Description | Parameters |
   | -------- | ----------- | ---------- |
-  | ERCF_SERVO_DOWN | Enguage the ERCF gear | None |
+  | ERCF_SERVO_DOWN | Engage the ERCF gear | None |
   | ERCF_SERVO_UP | Disengage the ERCF gear | None |
   | ERCF_MOTORS_OFF | Turn off both ERCF motors | None |
   | ERCF_BUZZ_GEAR_MOTOR | Buzz the ERCF gear motor and report on whether filament was detected | None |
   <br>
 
   ## Core ERCF functionality
-  | Commmand | Description | Parameters |
+  | Command | Description | Parameters |
   | -------- | ----------- | ---------- |
-  | ERCF_PRELOAD | Helper for filament loading. Feed filament into gate, ERCF will catch it and correctly positin at the specified gate | GATE=\[0..n\] The specific gate to preload. If ommitted the currently selected gate can be loaded |
+  | ERCF_PRELOAD | Helper for filament loading. Feed filament into gate, ERCF will catch it and correctly position at the specified gate | GATE=\[0..n\] The specific gate to preload. If omitted the currently selected gate can be loaded |
   | ERCF_UNLOCK | Unlock ERCF operations after a pause caused by error condition | None |
   | ERCF_HOME | Home the ERCF selector and optionally selects gate associated with the specified tool | TOOL=\[0..n\] After homing, select this gate as if ERCF_SELECT_GATE was called<br>FORCE_UNLOAD=\[0\|1\] ERCF will try to unload filament if it thinks it has to but this option will force it to check and attempt unload |
   | ERCF_SELECT_TOOL | Selects the gate associated with the specified tool | TOOL=\[0..n\] The tool to be selected (technically the gate associated with this tool will be selected) |
@@ -360,12 +360,12 @@ Good luck and hopefully a little less *enraged* printing.  You can find me on di
   | ERCF_CHANGE_TOOL | Perform a tool swap (generally called from 'Tx' macros) | TOOL=\[0..n\] <br>STANDALONE=\[0\|1\] Optional to force standalone logic (tip forming) |
   | ERCF_CHANGE_TOOL_STANDALONE | Deprecated. Perform tool swap outside of a print. Use 'ERCF_TOOL_CHANGE STANDALONE=1' if really necessary | TOOL=\[0..n\] |
   | ERCF_EJECT | Eject filament and park it in the ERCF gate | None |
-  | ERCF_PAUSE | Pause the current print and lock the ERCF operations | FORCE_IN_PRINT=\[0\|1\] This option forces the handling of pause as if it occured in print and is useful for testing |
+  | ERCF_PAUSE | Pause the current print and lock the ERCF operations | FORCE_IN_PRINT=\[0\|1\] This option forces the handling of pause as if it occurred in print and is useful for testing |
   | ERCF_RECOVER | Recover filament position (state). ERCF will generally do this for you can this may be use useful to call prior to RESUME if you intervene/manipulate filament by hand and want to confirm state | None |
   <br>
 
   ## User Testing
-  | Commmand | Description | Parameters |
+  | Command | Description | Parameters |
   | -------- | ----------- | ---------- |
   | ERCF_TEST_GRIP | Test the ERCF grip of the currently selected tool | None |
   | ERCF_TEST_SERVO | Test the servo angle | VALUE=.. Angle value sent to servo |
@@ -373,24 +373,24 @@ Good luck and hopefully a little less *enraged* printing.  You can find me on di
   | ERCF_TEST_LOAD_SEQUENCE | Soak testing of load sequence. Great for testing reliability and repeatability| LOOP=..\[10\] Number of times to loop while testing <br>RANDOM=\[0\|1\] Whether to randomize tool selection <br>FULL=\[0 \|1 \] Whether to perform full load to nozzle or short load just past encoder |
   | ERCF_TEST_LOAD | Test loading filament | LENGTH=..[100] Test load the specified length of filament into selected tool |
   | (ERCF_LOAD) | Identical to ERCF_TEST_LOAD | |
-  | ERCF_TEST_UNLOAD | Move the ERCF gear | LENGTH=..[100] Lenght of filament to be unloaded <br>UNKNOWN=\[0\|1\] Whether the state of the extruder is known. Generally 0 for standalone use, 1 simulates call as if it was from slicer when tip has already been formed |
+  | ERCF_TEST_UNLOAD | Move the ERCF gear | LENGTH=..[100] Length of filament to be unloaded <br>UNKNOWN=\[0\|1\] Whether the state of the extruder is known. Generally 0 for standalone use, 1 simulates call as if it was from slicer when tip has already been formed |
   | ERCF_TEST_HOME_TO_EXTRUDER | For calibrating extruder homing - TMC current setting, etc. | RETURN=\[0\|1\] Whether to return the filament to the approximate starting position after homing - good for repeated testing |
   | ERCF_TEST_TRACKING | Simple visual test to see how encoder tracks with gear motor | DIRECTION=\[-1\|1\] Direction to perform the test <br>STEP=\[0.5..20\] Size of individual steps<br>Defaults to load direction and 1mm step size |
   | ERCF_TEST_CONFIG | Dump / Change essential load/unload config options at runtime | Many. Best to run ERCF_TEST_CONFIG without options to report all parameters than can be specified |
   <br>
 
   ## Tool to Gate map and Endless spool
-  | Commmand | Description | Parameters |
+  | Command | Description | Parameters |
   | -------- | ----------- | ---------- |
   | ERCF_ENCODER_RUNOUT | Filament runout handler that will also implement EndlessSpool if enabled | RUNOUT=1 is useful for testing to validate your _ERCF_ENDLESS_SPOOL\*\* macros |
   | ERCF_DISPLAY_TTG_MAP | Displays the current Tool -> Gate mapping (can be used all the time but generally designed for EndlessSpool  | None |
   | ERCF_REMAP_TTG | Reconfiguration of the Tool - to - Gate (TTG) map.  Can also set gates as empty! | TOOL=\[0..n\] <br>GATE=\[0..n\] Maps specified tool to this gate (multiple tools can point to same gate) <br>AVAILABLE=\[0\|1\]  Marks gate as available or empty |
   | ERCF_RESET_TTG_MAP | Reset the Tool-to-Gate map back to default | None |
-  | ERCF_CHECK_GATES | Inspect the gate(s) and mark availability | GATE=\[0..n\] The specific gate to check. If ommitted all gates will be checked (the default) |
+  | ERCF_CHECK_GATES | Inspect the gate(s) and mark availability | GATE=\[0..n\] The specific gate to check. If omitted all gates will be checked (the default) |
   <br>
 
   ## User defined/configurable macros (in ercf_software.cfg)
-  | Commmand | Description | Parameters |
+  | Command | Description | Parameters |
   | -------- | ----------- | ---------- |
   | _ERCF_ENDLESS_SPOOL_PRE_UNLOAD | Called prior to unloading the remains of the current filament |
   | _ERCF_ENDLESS_SPOOL_POST_LOAD | Called subsequent to loading filament in the new gate in the sequence |

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -213,7 +213,7 @@ class Ercf:
             for i in range(len(self.selector_offsets)):
                 self.gate_status.append(self.GATE_AVAILABLE)
 
-        # Setup tool to gate map primariliy for endless spool use
+        # Setup tool to gate map primarily for endless spool use
         self.tool_to_gate_map = []
         for i in range(len(self.selector_offsets)):
             self.tool_to_gate_map.append(i)
@@ -257,12 +257,12 @@ class Ercf:
         self.gcode.register_command('ERCF_SET_LOG_LEVEL',
                     self.cmd_ERCF_SET_LOG_LEVEL,
                     desc = self.cmd_ERCF_SET_LOG_LEVEL_help)
-        self.gcode.register_command('ERCF_DISPLAY_ENCODER_POS', 
+        self.gcode.register_command('ERCF_DISPLAY_ENCODER_POS',
                     self.cmd_ERCF_DISPLAY_ENCODER_POS,
-                    desc = self.cmd_ERCF_DISPLAY_ENCODER_POS_help)                    
-        self.gcode.register_command('ERCF_STATUS', 
+                    desc = self.cmd_ERCF_DISPLAY_ENCODER_POS_help)
+        self.gcode.register_command('ERCF_STATUS',
                     self.cmd_ERCF_STATUS,
-                    desc = self.cmd_ERCF_STATUS_help)                    
+                    desc = self.cmd_ERCF_STATUS_help)
 
 	# Calibration
         self.gcode.register_command('ERCF_CALIBRATE',
@@ -273,7 +273,7 @@ class Ercf:
                     desc = self.cmd_ERCF_CALIBRATE_SINGLE_help)
         self.gcode.register_command('ERCF_CALIB_SELECTOR',
                     self.cmd_ERCF_CALIB_SELECTOR,
-                    desc = self.cmd_ERCF_CALIB_SELECTOR_help)     
+                    desc = self.cmd_ERCF_CALIB_SELECTOR_help)
         self.gcode.register_command('ERCF_CALIBRATE_ENCODER',
                     self.cmd_ERCF_CALIBRATE_ENCODER,
                     desc=self.cmd_ERCF_CALIBRATE_ENCODER_help)
@@ -281,7 +281,7 @@ class Ercf:
         # Servo and motor control
         self.gcode.register_command('ERCF_SERVO_DOWN',
                     self.cmd_ERCF_SERVO_DOWN,
-                    desc = self.cmd_ERCF_SERVO_DOWN_help)                       
+                    desc = self.cmd_ERCF_SERVO_DOWN_help)
         self.gcode.register_command('ERCF_SERVO_UP',
                     self.cmd_ERCF_SERVO_UP,
                     desc = self.cmd_ERCF_SERVO_UP_help)
@@ -325,12 +325,12 @@ class Ercf:
                     desc = self.cmd_ERCF_RECOVER_help)
 
 	# User Testing
-        self.gcode.register_command('ERCF_TEST_GRIP', 
+        self.gcode.register_command('ERCF_TEST_GRIP',
                     self.cmd_ERCF_TEST_GRIP,
                     desc = self.cmd_ERCF_TEST_GRIP_help)
         self.gcode.register_command('ERCF_TEST_SERVO',
                     self.cmd_ERCF_TEST_SERVO,
-                    desc = self.cmd_ERCF_TEST_SERVO_help)                          
+                    desc = self.cmd_ERCF_TEST_SERVO_help)
         self.gcode.register_command('ERCF_TEST_MOVE_GEAR',
                     self.cmd_ERCF_TEST_MOVE_GEAR,
                     desc = self.cmd_ERCF_TEST_MOVE_GEAR_help)
@@ -342,7 +342,7 @@ class Ercf:
                     desc=self.cmd_ERCF_TEST_LOAD_help)
         self.gcode.register_command('ERCF_LOAD',
                     self.cmd_ERCF_TEST_LOAD,
-                    desc=self.cmd_ERCF_TEST_LOAD_help) # For backwards compatability because it's mentioned in manual, but prefer to remove
+                    desc=self.cmd_ERCF_TEST_LOAD_help) # For backwards compatibility because it's mentioned in manual, but prefer to remove
         self.gcode.register_command('ERCF_TEST_TRACKING',
                     self.cmd_ERCF_TEST_TRACKING,
                     desc=self.cmd_ERCF_TEST_TRACKING_help)
@@ -351,13 +351,13 @@ class Ercf:
                     desc=self.cmd_ERCF_TEST_UNLOAD_help)
         self.gcode.register_command('ERCF_TEST_HOME_TO_EXTRUDER',
                     self.cmd_ERCF_TEST_HOME_TO_EXTRUDER,
-                    desc = self.cmd_ERCF_TEST_HOME_TO_EXTRUDER_help)    
+                    desc = self.cmd_ERCF_TEST_HOME_TO_EXTRUDER_help)
         self.gcode.register_command('ERCF_TEST_CONFIG',
                     self.cmd_ERCF_TEST_CONFIG,
-                    desc = self.cmd_ERCF_TEST_CONFIG_help)                    
+                    desc = self.cmd_ERCF_TEST_CONFIG_help)
 
         # Runout and Endless spool
-        self.gcode.register_command('ERCF_ENCODER_RUNOUT', 
+        self.gcode.register_command('ERCF_ENCODER_RUNOUT',
                     self.cmd_ERCF_ENCODER_RUNOUT,
                     desc = self.cmd_ERCF_ENCODER_RUNOUT_help)
         self.gcode.register_command('ERCF_DISPLAY_TTG_MAP',
@@ -577,7 +577,7 @@ class Ercf:
             rounded = self.gate_statistics[gate]
             load_slip_percent = (rounded['load_delta'] / rounded['load_distance']) * 100 if rounded['load_distance'] != 0. else 0.
             unload_slip_percent = (rounded['unload_delta'] / rounded['unload_distance']) * 100 if rounded['unload_distance'] != 0. else 0.
-            # Give the gate a reliabilty grading based on slippage
+            # Give the gate a reliability grading based on slippage
             grade = load_slip_percent + unload_slip_percent
             if grade < 2.:
                 status = "Good"
@@ -863,7 +863,7 @@ class Ercf:
                 self._servo_down()
                 self._counter.reset_counts()    # Encoder 0000
                 encoder_moved = self._load_encoder()
-                self._load_bowden(self.calibration_bowden_length - encoder_moved)     
+                self._load_bowden(self.calibration_bowden_length - encoder_moved)
                 self._log_info("Finding extruder gear position (try #%d of %d)..." % (i+1, repeats))
                 self._home_to_extruder(extruder_homing_length)
                 measured_movement = self._counter.get_distance()
@@ -908,7 +908,7 @@ class Ercf:
                 self._log_always("Recommended calibration reference based on current configuration options is %.1f" % average_reference)
                 self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=ercf_calib_ref VALUE=%.1f" % average_reference)
                 self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=ercf_calib_clog_length VALUE=%.1f" % spring_based_detection_length)
-                self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=ercf_calib_0 VALUE=1.0")  
+                self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=ercf_calib_0 VALUE=1.0")
                 self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=ercf_calib_version VALUE=3")
                 if self.enable_clog_detection:
                     self._log_always("Automatically setting clog 'detection_length' to: %.1f" % spring_based_detection_length)
@@ -937,7 +937,7 @@ class Ercf:
             ratio = (test_length * 2) / (measurement - encoder_moved)
             self._log_always("Calibration move of %.1fmm, average encoder measurement %.1fmm - Ratio is %.6f" % (test_length * 2, measurement - encoder_moved, ratio))
             if not tool == 0:
-                self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=ercf_calib_%d VALUE=%.6f" % (tool, ratio))  
+                self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=ercf_calib_%d VALUE=%.6f" % (tool, ratio))
             self._unload_encoder(self.unload_buffer)
             self._servo_up()
             self._set_loaded_status(self.LOADED_STATUS_UNLOADED)
@@ -955,7 +955,7 @@ class Ercf:
             stdev = math.sqrt( sum(diff2) / max((len(values) - 1), 1))
             vmin = min(values)
             vmax = max(values)
-        return {'mean': mean, 'stdev': stdev, 'min': vmin, 'max': vmax, 'range': vmax - vmin}        
+        return {'mean': mean, 'stdev': stdev, 'min': vmin, 'max': vmax, 'range': vmax - vmin}
 
 ### CALIBRATION GCODE COMMANDS
 
@@ -1488,8 +1488,8 @@ class Ercf:
             gear_stepper_run_current = self.tmc.get_status(0)['run_current']
             self._log_debug("Temporarily reducing gear_stepper run current to %d%% for collision detection"
                                 % self.extruder_homing_current)
-            self.gcode.run_script_from_command("SET_TMC_CURRENT STEPPER=gear_stepper CURRENT=%.1f"
-                                                % ((gear_stepper_run_current * self.extruder_homing_current)/100))
+            self.gcode.run_script_from_command("SET_TMC_CURRENT STEPPER=gear_stepper CURRENT=%.2f"
+                                                % ((gear_stepper_run_current * self.extruder_homing_current)/100.0))
 
         initial_encoder_position = self._counter.get_distance()
         homed = False
@@ -1505,7 +1505,7 @@ class Ercf:
         self._log_debug("Extruder %s found after %.1fmm move (%d steps), encoder measured %.1fmm (total_delta %.1fmm)"
                 % ("not" if not homed else "", step*(i+1), i+1, measured_movement, total_delta))
         if self.tmc and self.extruder_homing_current < 100:
-            self.gcode.run_script_from_command("SET_TMC_CURRENT STEPPER=gear_stepper CURRENT=%.1f" % gear_stepper_run_current)
+            self.gcode.run_script_from_command("SET_TMC_CURRENT STEPPER=gear_stepper CURRENT=%.2f" % gear_stepper_run_current)
 
         if total_delta > 5.0:
             self._log_info("Warning: A lot of slippage was detected whilst homing to extruder, you may want to reduce 'extruder_homing_current' and/or ensure a good grip on filament by gear drive")
@@ -1544,7 +1544,7 @@ class Ercf:
             msg = "Homing step #%d" % (i+1)
             delta = self._trace_filament_move(msg, step, speed=10, motor="both" if sync else "extruder")
             if self.toolhead_sensor.runout_helper.filament_present:
-                self._log_debug("Toolhead sensor reached after %.1fmm (%d moves)" % (step*(i+1), i+1))                
+                self._log_debug("Toolhead sensor reached after %.1fmm (%d moves)" % (step*(i+1), i+1))
                 break
 
         if self.toolhead_sensor.runout_helper.filament_present:
@@ -1594,7 +1594,7 @@ class Ercf:
         total_delta = self.home_position_to_nozzle - measured_movement
         self._log_debug("Total measured movement: %.1fmm, total delta: %.1fmm" % (measured_movement, total_delta))
         if total_delta > (length * 0.80):   # 80% of final move length
-            raise ErcfError("Move to nozzle failed (encoder not sensing sufficent movement). Extruder may not have picked up filament")
+            raise ErcfError("Move to nozzle failed (encoder not sensing sufficient movement). Extruder may not have picked up filament")
 
         self._set_loaded_status(self.LOADED_STATUS_FULL)
         self._log_info('ERCF load successful')
@@ -1671,7 +1671,7 @@ class Ercf:
         finally:
             self._track_unload_end()
 
-    # This is a recovery routine to determine the most conservate location of the filament for unload purposes
+    # This is a recovery routine to determine the most conservative location of the filament for unload purposes
     def _recover_loaded_state(self):
         self.need_to_recover_state = False
         toolhead_sensor_state = self._check_toolhead_sensor()
@@ -1701,8 +1701,8 @@ class Ercf:
         self._servo_up()
 
         # Goal is to exit extruder. Two strategies depending on availability of toolhead sensor
-        # Back up 15mm at a time until either the encoder doesnt see any movement or toolhead sensor reports clear
-        # Do this until we have travelled more than the length of the extruder 
+        # Back up 15mm at a time until either the encoder doesn't see any movement or toolhead sensor reports clear
+        # Do this until we have traveled more than the length of the extruder 
         max_length = self.home_position_to_nozzle + self.toolhead_homing_max + 10.
         step = self.encoder_move_step_size
         self._log_debug("Trying to exit the extruder, up to %.1fmm in %.1fmm steps" % (max_length, step))
@@ -1716,14 +1716,14 @@ class Ercf:
             if self.toolhead_sensor != None:
                 if not self.toolhead_sensor.runout_helper.filament_present:
                     self._set_loaded_status(self.LOADED_STATUS_PARTIAL_HOMED_SENSOR)
-                    self._log_debug("Toolhead sensor reached after %d moves" % (i+1))                
+                    self._log_debug("Toolhead sensor reached after %d moves" % (i+1))
                     # Last move to ensure we are really free because of small space between sensor and gears
                     delta = self._trace_filament_move("Last sanity move", -self.toolhead_homing_max, speed=speed, motor="extruder")
                     out_of_extruder = True
                     break
             else:
                 if (self.encoder_move_step_size - delta) <= 1.0:
-                    self._log_debug("Extruder entrance reached after %d moves" % (i+1))                
+                    self._log_debug("Extruder entrance reached after %d moves" % (i+1))
                     out_of_extruder = True
                     break
 
@@ -1804,7 +1804,7 @@ class Ercf:
                 return
         raise ErcfError("Unable to get the filament out of the encoder cart")
 
-    # Form tip and return True if encoder movement occured
+    # Form tip and return True if encoder movement occurred
     def _form_tip_standalone(self):
         self.toolhead.wait_moves()
         park_pos = 35.  # TODO cosmetic: bring in from tip forming (parking position in extruder)
@@ -2043,7 +2043,7 @@ class Ercf:
             stepper.set_step_dist(new_step_dist)
 
 
-### CORE GOCDE COMMMANDS ##########################################################
+### CORE GCODE COMMANDS ##########################################################
 
     cmd_ERCF_UNLOCK_help = "Unlock ERCF operations"
     def cmd_ERCF_UNLOCK(self, gcmd):        
@@ -2148,7 +2148,7 @@ class Ercf:
         self._recover_loaded_state()
 
 
-### GOCDE COMMMANDS INTENDED FOR TESTING #####################################
+### GCODE COMMANDS INTENDED FOR TESTING #####################################
 
     cmd_ERCF_TEST_GRIP_help = "Test the ERCF grip for a Tool"
     def cmd_ERCF_TEST_GRIP(self, gcmd):
@@ -2428,7 +2428,7 @@ class Ercf:
             self.gate_status[i] = self.GATE_AVAILABLE
         self._unselect_tool()
 
-### GOCDE COMMMANDS FOR RUNOUT and GATE LOGIC ##################################
+### GCODE COMMANDS FOR RUNOUT and GATE LOGIC ##################################
 
     cmd_ERCF_ENCODER_RUNOUT_help = "Encoder runout handler"
     def cmd_ERCF_ENCODER_RUNOUT(self, gcmd):


### PR DESCRIPTION
Allow for 2 decimals when setting TMC DRIVER CURRENT to support for more fine grained stepper current reduction during extruder collision detection. Also some minor spelling and anal retentiveness.