### PR TITLE
Gear extruder sync

### DIFF
--- a/doc/sync_gear_to_extruder.md
+++ b/doc/sync_gear_to_extruder.md
@@ -1,0 +1,19 @@
+
+The ERCF system now offers the optional feature of coordinating its gear motor with the extruder stepper during printing. This added functionality enhances the filament pulling torque, potentially alleviating friction-related problems. It is crucial, however, to maintain precise rotational distances for both the primary extruder stepper and the gear stepper. A mismatch in filament transfer speeds between these components could lead to undue stress and filament grinding.
+
+# Setting up Synchronization
+
+- Modify the section title `[manual_stepper gear_stepper]` to `[manual_extruder_stepper gear_stepper]`.
+- Within the `ercf_parameters.cfg` file, include `sync_to_extruder: <target_extruder>`. Here, `<target_extruder>` represents the extruder which is to be coordinated with the ERCF's gear stepper. In most cases, this will simply be `sync_to_extruder: extruder`.
+
+# Synchronization Workflow
+
+If the `sync_to_extruder` feature is activated, the gear stepper will automatically coordinate with the extruder stepper following a successful tool change. Any ERCF operation that necessitates the gear stepper's movement (like when unloading the filament or buzzing the gear stepper to verify filament engagement), will automatically disengage the sync. Generally, you don't need to manually manage the coordination/discoordination of the gear stepper — the ERCF software handles the majority of these actions. However, if the printer enters ERCF_PAUSE state (due to a filament jam or runout, for example), synchronization is automatically disengaged. Upon resuming a print, you should either manually invoke a tool change, which will implicity sync the steppers again, or use the `cmd_ERCF_SYNC_GEAR_MOTOR` command to reestablish coordination with the gear stepper.
+
+The `cmd_ERCF_SYNC_GEAR_MOTOR sync={0|1} servo={0|1}` command functions as follows:
+- Defaults to `sync=1` and `servo=1`
+- If `sync=1` and `servo=1`, it triggers the servo and executes the synchronization
+- If `sync=1` and `servo=0`, it performs only the synchronization
+- If `sync=0`, it always disengages synchronization while maintaining the servo's status (ignores the servo parameter)
+
+Much like a `manual_stepper`, you have the option to manually control a `manual_extruder_stepper` using the `MANUAL_STEPPER` command. This command, however, will only be effective if the stepper is not currently coordinated with the extruder.

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -21,7 +21,6 @@
 import logging, logging.handlers, threading, queue, time
 import textwrap, math, os.path, re, json
 from random import randint
-from kinematics import extruder
 
 # Forward all messages through a queue (polled by background thread)
 class QueueHandler(logging.Handler):
@@ -1127,7 +1126,10 @@ class Ercf:
     def cmd_ERCF_SYNC_GEAR_MOTOR(self, gcmd):
         if self._check_is_disabled(): return
         if self._check_in_bypass(): return
+        servo = gcmd.get_int('SERVO', 1, minval=0, maxval=1)
         sync = gcmd.get_int('SYNC', 1, minval=0, maxval=1)
+        if servo and sync:
+            self._servo_down()
         self._sync_gear_to_extruder(sync)
 
 #########################

--- a/extras/manual_extruder_stepper.py
+++ b/extras/manual_extruder_stepper.py
@@ -1,0 +1,118 @@
+# Support for an extruder stepper that can be manually controlled when it is not synced to its motion queue
+#
+# Copyright (C) 2023 Cambridge Yang <camyang@mit.csail.edu>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import stepper, chelper
+from kinematics import extruder as kinematics_extruder
+from . import manual_stepper
+
+class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.ManualStepper):
+    """Extruder stepper that can be manually controlled when it is not synced to its motion queue"""
+
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.pressure_advance = self.pressure_advance_smooth_time = 0.
+        self.config_pa = config.getfloat('pressure_advance', 0., minval=0.)
+        self.config_smooth_time = config.getfloat(
+                'pressure_advance_smooth_time', 0.040, above=0., maxval=.200)
+        # Setup stepper
+        if config.get('endstop_pin', None) is not None:
+            self.can_home = True
+            self.stepper = stepper.PrinterRail(
+                config, need_position_minmax=False, default_position_endstop=0.)
+            self.steppers = self.stepper.get_steppers()
+        else:
+            self.can_home = False
+            self.stepper = stepper.PrinterStepper(config)
+            self.steppers = [self.stepper]
+        self.rail = self.stepper # for forwarding manual_stepper...
+
+        self.velocity = config.getfloat('velocity', 5., above=0.)
+        self.accel = self.homing_accel = config.getfloat('accel', 0., minval=0.)
+        self.next_cmd_time = 0.
+
+        ffi_main, ffi_lib = chelper.get_ffi()
+
+        # setup iterative solver for manual movement
+        self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
+        self.trapq_append = ffi_lib.trapq_append
+        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
+        self.rail.setup_itersolve('cartesian_stepper_alloc', b'x')
+        self.rail.set_trapq(self.trapq)
+
+        # setup extruder kinematics
+        self.sk_extruder = ffi_main.gc(ffi_lib.extruder_stepper_alloc(),
+                                       ffi_lib.free)
+        self.alt_stepper_sks = [s.set_stepper_kinematics(self.sk_extruder) 
+                                for s in self.steppers]
+        self.motion_queue = None
+
+        # Register commands
+        self.printer.register_event_handler("klippy:connect",
+                                            self._handle_connect)
+        gcode = self.printer.lookup_object('gcode')
+        if self.name == 'extruder':
+            gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER", None,
+                                       self.cmd_default_SET_PRESSURE_ADVANCE,
+                                       desc=self.cmd_SET_PRESSURE_ADVANCE_help)
+        gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER",
+                                   self.name, self.cmd_SET_PRESSURE_ADVANCE,
+                                   desc=self.cmd_SET_PRESSURE_ADVANCE_help)
+        gcode.register_mux_command("SET_EXTRUDER_ROTATION_DISTANCE", "EXTRUDER",
+                                   self.name, self.cmd_SET_E_ROTATION_DISTANCE,
+                                   desc=self.cmd_SET_E_ROTATION_DISTANCE_help)
+        gcode.register_mux_command("SYNC_EXTRUDER_MOTION", "EXTRUDER",
+                                   self.name, self.cmd_SYNC_EXTRUDER_MOTION,
+                                   desc=self.cmd_SYNC_EXTRUDER_MOTION_help)
+        gcode.register_mux_command("SET_EXTRUDER_STEP_DISTANCE", "EXTRUDER",
+                                   self.name, self.cmd_SET_E_STEP_DISTANCE,
+                                   desc=self.cmd_SET_E_STEP_DISTANCE_help)
+        gcode.register_mux_command("SYNC_STEPPER_TO_EXTRUDER", "STEPPER",
+                                   self.name, self.cmd_SYNC_STEPPER_TO_EXTRUDER,
+                                   desc=self.cmd_SYNC_STEPPER_TO_EXTRUDER_help)
+        gcode.register_mux_command('MANUAL_STEPPER', "STEPPER",
+                                   self.name, self.cmd_MANUAL_STEPPER,
+                                   desc=self.cmd_MANUAL_STEPPER_help)
+
+
+    def do_enable(self, enable):
+        assert self.motion_queue is None
+        return super().do_enable(enable)
+    
+    def do_set_position(self, setpos):
+        assert self.motion_queue is None
+        return super().do_set_position(setpos)
+    
+    def do_move(self, movepos, speed, accel, sync=True):
+        assert self.motion_queue is None
+        return super().do_move(movepos, speed, accel, sync)
+
+    def cmd_MANUAL_STEPPER(self, gcmd):
+        if self.motion_queue is not None:
+            raise self.printer.command_error("Cannot manual move: stepper synced to motion queue")
+        return manual_stepper.ManualStepper.cmd_MANUAL_STEPPER(self, gcmd)
+
+    def sync_to_extruder(self, extruder_name):
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.flush_step_generation()
+        if not extruder_name:
+            for s, sk in zip(self.steppers, self.alt_stepper_sks):
+                s.set_stepper_kinematics(sk)
+            self.rail.set_trapq(self.trapq)
+            self.motion_queue = None
+            return
+        extruder = self.printer.lookup_object(extruder_name, None)
+        if extruder is None or not isinstance(extruder, kinematics_extruder.PrinterExtruder):
+            raise self.printer.command_error("'%s' is not a valid extruder."
+                                             % (extruder_name,))
+        for s in self.steppers:
+            s.set_stepper_kinematics(self.sk_extruder)
+        self.rail.set_position([extruder.last_position, 0., 0.])
+        self.rail.set_trapq(extruder.get_trapq())
+        self.motion_queue = extruder_name
+
+def load_config_prefix(config):
+    return ManualExtruderStepper(config)

--- a/extras/manual_extruder_stepper.py
+++ b/extras/manual_extruder_stepper.py
@@ -1,6 +1,6 @@
 # Support for an extruder stepper that can be manually controlled when it is not synced to its motion queue
 #
-# Copyright (C) 2023 Cambridge Yang <camyang@mit.csail.edu>
+# Copyright (C) 2023 Cambridge Yang <camyang@csail.mit.edu>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -46,7 +46,7 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
         # setup extruder kinematics
         self.sk_extruder = ffi_main.gc(ffi_lib.extruder_stepper_alloc(),
                                        ffi_lib.free)
-        self.alt_stepper_sks = [s.set_stepper_kinematics(self.sk_extruder) 
+        self.alt_stepper_sks = [s.set_stepper_kinematics(self.sk_extruder)
                                 for s in self.steppers]
         self.motion_queue = None
 


### PR DESCRIPTION
Hi!

This starts a formal PR to bringing the extruder syncing feature into HH. I ended up cleaning up some of my hacky code and properly implemented a `manual_extruder_stepper` plugin that allows a stepper to sync to an extruder's motion queue, or be manually moved when it is not synced. 

Currently this code should work, and it prints well with my printer --- it seems to have solved my friction issues! However, this is not extensively tested so far, so more eyes (or print time) are needed.

Please let me know of any feedbacks. I will also keep work on this branch for any potential fixes/improvements. 

Thank you 