### PR TITLE
guarantee that we are always above the min extrusion temperture

### DIFF
--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -1629,13 +1629,15 @@ class Ercf:
             return print_status
 
     def _set_above_min_temp(self, temp=-1):
+        extruder_heater = self.printer.lookup_object("extruder").heater
         if temp == -1:
-            if self.printer.lookup_object("extruder").heater.target_temp >= self.min_temp_extruder:
-                return
-            temp = self.min_temp_extruder
+            if extruder_heater.target_temp >= self.min_temp_extruder:
+                temp = extruder_heater.target_temp
+            else:
+                temp = self.min_temp_extruder
             self._log_error("Heating extruder to minimum temp (%.1f)" % temp)
         else:
-            if self.printer.lookup_object("extruder").heater.target_temp < temp and temp > 40:
+            if extruder_heater.target_temp < temp and temp > 40:
                 self._log_info("Heating extruder to desired temp (%.1f)" % temp)
             else:
                 return

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -1630,7 +1630,7 @@ class Ercf:
 
     def _set_above_min_temp(self, temp=-1):
         if temp == -1:
-            if self.printer.lookup_object("extruder").heater.can_extrude:
+            if self.printer.lookup_object("extruder").heater.target_temp >= self.min_temp_extruder:
                 return
             temp = self.min_temp_extruder
             self._log_error("Heating extruder to minimum temp (%.1f)" % temp)


### PR DESCRIPTION
This fixes the problem where we might enter a ERCF command with a hot enough temperature, but the temperature drops during the command since no target was set.