### PR TITLE
add support for multiple toolhead extruder setting so that ERCF can p…

### DIFF
--- a/ercf_parameters.cfg
+++ b/ercf_parameters.cfg
@@ -145,7 +145,7 @@ persistence_level: 3
 
 
 # Advanced: Configurable, but fairly fixed values ------------------------------------------------------------------------
-extruder_name: extruder		# Name of the extruder that ERCF is using
+extruder_name: extruder		# Name of the toolhead extruder that ERCF is using
 timeout_pause: 72000		# Time out in seconds used by the ERCF_PAUSE
 disable_heater: 600		# Delay in seconds after which the hotend heater is disabled in the ERCF_PAUSE state
 min_temp_extruder: 200		# Used to ensure we can move the extruder and form tips


### PR DESCRIPTION
This unifies the usage of `extruder_name` and should really allow us to have multiple toolhead extruders. Note that with multiple toolhead extruders, klipper has this convention that they will called `extruder1`, `extruder2` etc.  See [config refence](extruder_name_handling)