### PR TITLE
Buffer vs spool loading speed

### DIFF
--- a/ercf_parameters.cfg
+++ b/ercf_parameters.cfg
@@ -10,7 +10,7 @@ servo_down_angle: {servo_down_angle}			# Default: MG90S servo: Down=140 ; SAVOX 
 # 100mm/s should be "quiet" with the NEMA14 motor or a NEMA17 pancake, but you can go lower for really low noise
 # NOTE: Encoder cannot keep up much above 200mm/s so make sure `apply_bowden_correction` is off at high speeds!
 long_moves_speed: 150			# mm/s. Conservative value is 100mm/s, Max around 300mm/s
-# long_moves_speed_from_spool: 50    # mm/s. Uncomment to use a lower speed when loading from a gate for the first time. This is helpful if pulling from the spool requires more force when pulling from a filament buffer.
+# long_moves_speed_from_spool: 50    # mm/s. Uncomment to use a lower speed when loading from a gate for the first time. This is helpful if pulling from the spool requires more force than pulling from a filament buffer.
 short_moves_speed: 50			# mm/s. Conservative value is 35mm/s. Max around 100mm/s
 
 

--- a/ercf_parameters.cfg
+++ b/ercf_parameters.cfg
@@ -10,6 +10,7 @@ servo_down_angle: {servo_down_angle}			# Default: MG90S servo: Down=140 ; SAVOX 
 # 100mm/s should be "quiet" with the NEMA14 motor or a NEMA17 pancake, but you can go lower for really low noise
 # NOTE: Encoder cannot keep up much above 200mm/s so make sure `apply_bowden_correction` is off at high speeds!
 long_moves_speed: 150			# mm/s. Conservative value is 100mm/s, Max around 300mm/s
+# long_moves_speed_from_spool: 50    # mm/s. Uncomment to use a lower speed when loading from a gate for the first time. This is helpful if pulling from the spool requires more force when pulling from a filament buffer.
 short_moves_speed: 50			# mm/s. Conservative value is 35mm/s. Max around 100mm/s
 
 

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -1791,7 +1791,7 @@ class Ercf:
             if is_long_move:
                 if (dist > 0 and
                     self.gate_selected >= 0 and
-                    self.gate_status[self.gate_selected] == self.GATE_AVAILABLE):
+                    self.gate_status[self.gate_selected] != self.GATE_AVAILABLE_FROM_BUFFER):
                     # Long pulling move when we are sure that we are at a gate but the filament buffer might be empty
                     speed = self.long_moves_speed_from_spool
                 else:

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -3222,6 +3222,7 @@ class Ercf:
     cmd_ERCF_TEST_CONFIG_help = "Runtime adjustment of ERCF configuration for testing or in-print tweaking purposes"
     def cmd_ERCF_TEST_CONFIG(self, gcmd):
         self.long_moves_speed = gcmd.get_float('LONG_MOVES_SPEED', self.long_moves_speed, above=20.)
+        self.long_moves_speed_from_spool = gcmd.get_float('LONG_MOVES_SPEED_FROM_SPOOL', self.long_moves_speed_from_spool, above=20.)
         self.short_moves_speed = gcmd.get_float('SHORT_MOVES_SPEED', self.short_moves_speed, above=20.)
         self.home_to_extruder = gcmd.get_int('HOME_TO_EXTRUDER', self.home_to_extruder, minval=0, maxval=1)
         self.ignore_extruder_load_error = gcmd.get_int('IGNORE_EXTRUDER_LOAD_ERROR', self.ignore_extruder_load_error, minval=0, maxval=1)
@@ -3263,6 +3264,7 @@ class Ercf:
         if clog_length != self.encoder_sensor.get_clog_detection_length():
             self.encoder_sensor.set_clog_detection_length(clog_length)
         msg = "long_moves_speed = %.1f" % self.long_moves_speed
+        msg = "long_moves_speed_from_spool = %.1f" % self.long_moves_speed_from_spool
         msg += "\nshort_moves_speed = %.1f" % self.short_moves_speed
         msg += "\nhome_to_extruder = %d" % self.home_to_extruder
         msg += "\nignore_extruder_load_error = %d" % self.ignore_extruder_load_error


### PR DESCRIPTION
This PR adds an optional config entry `long_moves_speed_from_spool`. By default, this value is the same as `long_moves_speed` and the behavior is same as before. If `long_moves_speed_from_spool` is provided, ERCF will pull at a lower speed if the filament could be directly pulling from the spool. 

In practice, this means that the first load from a gate (since last ERCF gates' states reset) will be a slow move, and the rest of the loading moves from the gate will be fast, where we assume the filament is in some kind of filament buffer. 

This allows greater torque of the gear stepper and avoids loosing steps at high speed.