### PR TITLE
Extruder homing

### DIFF
--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -1982,6 +1982,24 @@ class Ercf:
         self.gear_stepper.sync_to_extruder(gear_stepper_mq)
 
 
+    def _gear_home_to_endstop(self, endstop, movpos, speed=10, accel=100, triggered=True, check_trigger=True):
+        name = self.gear_stepper.steppers[0].get_name(short=True)
+        gear_stepper_rail_endstops = self.gear_stepper.rail.endstops
+        self.gear_stepper.rail.endstops = [(endstop, name)]
+        self.gear_stepper.rail.set_position([0, 0, 0, 0])
+        # TODO: implement "twice homing"?
+        try:
+            homing_result = self.gear_stepper.do_homing_move(
+                movpos,
+                speed=speed, 
+                accel=accel,
+                triggered=triggered,
+                check_trigger=check_trigger)
+        finally:
+            self.gear_stepper.rail.endstops = gear_stepper_rail_endstops
+        return homing_result
+
+
 ###########################
 # FILAMENT LOAD FUNCTIONS #
 ###########################
@@ -2164,12 +2182,13 @@ class Ercf:
         if self.sync_load_extruder and not skip_entry_moves:
             # Newer simplified forced full sync move
             with self._sync_toolhead_to_gear():
-                name = self.gear_stepper.steppers[0].get_name(short=True)
-                gear_stepper_rail_endstops = self.gear_stepper.rail.endstops
-                self.gear_stepper.rail.endstops = [(self.toolhead_sensor_mcu_endstop, name)]
-                self.gear_stepper.rail.set_position([0, 0, 0, 0])
-                self.gear_stepper.do_homing_move(self.toolhead_homing_max, speed=10, accel=self.gear_homing_accel, triggered=True, check_trigger=False) # TODO: make these speed/accel configurable?
-                self.gear_stepper.rail.endstops = gear_stepper_rail_endstops
+                self._gear_home_to_endstop(
+                    self.toolhead_sensor_mcu_endstop, 
+                    self.toolhead_homing_max,
+                    speed=10, # TODO: make these speed/accel configurable?
+                    accel=self.gear_homing_accel,
+                    triggered=True,
+                    check_trigger=False)
         else:
             # Original method either synced or extruder only
             sync = not skip_entry_moves and self.sync_load_length > 0.

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -1983,13 +1983,14 @@ class Ercf:
 
 
     def _gear_home_to_endstop(self, endstop, movepos, speed=10, accel=100, triggered=True, check_trigger=True):
+        self.gear_stepper.do_set_position(-movepos)
         name = self.gear_stepper.steppers[0].get_name(short=True)
         gear_stepper_rail_endstops = self.gear_stepper.rail.endstops
         self.gear_stepper.rail.endstops = [(endstop, name)]
         # TODO: implement "twice homing"?
         try:
             homing_result = self.gear_stepper.do_homing_move(
-                movepos,
+                0,
                 speed=speed,
                 accel=accel,
                 triggered=triggered,
@@ -2180,7 +2181,6 @@ class Ercf:
 
         if self.sync_load_extruder and not skip_entry_moves:
             # Newer simplified forced full sync move
-            self.gear_stepper.do_set_position(0.)
             with self._sync_toolhead_to_gear():
                 self._gear_home_to_endstop(
                     self.toolhead_sensor_mcu_endstop,
@@ -2189,6 +2189,8 @@ class Ercf:
                     accel=self.gear_homing_accel,
                     triggered=True,
                     check_trigger=False)
+                # resets the filament runout length since homing the extruder changed its position
+                self.encoder_sensor.enable()
         else:
             # Original method either synced or extruder only
             sync = not skip_entry_moves and self.sync_load_length > 0.

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -1982,16 +1982,15 @@ class Ercf:
         self.gear_stepper.sync_to_extruder(gear_stepper_mq)
 
 
-    def _gear_home_to_endstop(self, endstop, movpos, speed=10, accel=100, triggered=True, check_trigger=True):
+    def _gear_home_to_endstop(self, endstop, movepos, speed=10, accel=100, triggered=True, check_trigger=True):
         name = self.gear_stepper.steppers[0].get_name(short=True)
         gear_stepper_rail_endstops = self.gear_stepper.rail.endstops
         self.gear_stepper.rail.endstops = [(endstop, name)]
-        self.gear_stepper.rail.set_position([0, 0, 0, 0])
         # TODO: implement "twice homing"?
         try:
             homing_result = self.gear_stepper.do_homing_move(
-                movpos,
-                speed=speed, 
+                movepos,
+                speed=speed,
                 accel=accel,
                 triggered=triggered,
                 check_trigger=check_trigger)
@@ -2181,9 +2180,10 @@ class Ercf:
 
         if self.sync_load_extruder and not skip_entry_moves:
             # Newer simplified forced full sync move
+            self.gear_stepper.do_set_position(0.)
             with self._sync_toolhead_to_gear():
                 self._gear_home_to_endstop(
-                    self.toolhead_sensor_mcu_endstop, 
+                    self.toolhead_sensor_mcu_endstop,
                     self.toolhead_homing_max,
                     speed=10, # TODO: make these speed/accel configurable?
                     accel=self.gear_homing_accel,

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -354,9 +354,6 @@ class Ercf:
                     desc=self.cmd_ERCF_SYNC_GEAR_MOTOR_help)
 
 	# Core ERCF functionality
-        self.gcode.register_command('ERCF_TESTTEST',
-                    self.cmd_ERCF_TESTTEST,
-                    desc = self.cmd_ERCF_TESTTEST_help)
         self.gcode.register_command('ERCF_ENABLE',
                     self.cmd_ERCF_ENABLE,
                     desc = self.cmd_ERCF_ENABLE_help)
@@ -2846,12 +2843,6 @@ class Ercf:
 
 
 ### CORE GCODE COMMANDS ##########################################################
-
-    cmd_ERCF_TESTTEST_help = "Test ERCF"
-    def cmd_ERCF_TESTTEST(self, gcmd):
-        with self._sync_toolhead_to_gear():
-            self.gear_stepper.rail.set_position([0, 0, 0, 0])
-            self.gear_stepper.do_move(50, 50, 200)
 
     cmd_ERCF_UNLOCK_help = "Unlock ERCF operations"
     def cmd_ERCF_UNLOCK(self, gcmd):

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -21,6 +21,7 @@
 import logging, logging.handlers, threading, queue, time
 import textwrap, math, os.path, re, json
 from random import randint
+from extras import homing
 
 # Forward all messages through a queue (polled by background thread)
 class QueueHandler(logging.Handler):

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -200,6 +200,7 @@ class Ercf:
         self.home_to_extruder = config.getint('home_to_extruder', 0, minval=0, maxval=1)
         self.ignore_extruder_load_error = config.getint('ignore_extruder_load_error', 0, minval=0, maxval=1)
         self.extruder_homing_max = config.getfloat('extruder_homing_max', 50., above=20.)
+        self.extruder_homing_step = config.getfloat('extruder_homing_step', 2., minval=0.5, maxval=5.)
         self.extruder_homing_current = config.getint('extruder_homing_current', 50, minval=10, maxval=100)
         self.extruder_form_tip_current = config.getint('extruder_form_tip_current', 100, minval=100, maxval=150)
         self.toolhead_homing_max = config.getfloat('toolhead_homing_max', 20., minval=0.)

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -21,8 +21,6 @@
 import logging, logging.handlers, threading, queue, time, contextlib
 import textwrap, math, os.path, re, json
 from random import randint
-import toolhead
-from extras import homing
 
 # Forward all messages through a queue (polled by background thread)
 class QueueHandler(logging.Handler):

--- a/extras/manual_extruder_stepper.py
+++ b/extras/manual_extruder_stepper.py
@@ -112,7 +112,7 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
 
     def do_homing_move(self, movepos, speed, accel, triggered, check_trigger):
         assert self.motion_queue is None
-        return super(ManualExtruderStepper, self).do_homing_move(self, movepos, speed, accel, triggered, check_trigger)
+        return super(ManualExtruderStepper, self).do_homing_move(movepos, speed, accel, triggered, check_trigger)
 
     def cmd_MANUAL_STEPPER(self, gcmd):
         if self.motion_queue is not None:

--- a/extras/manual_extruder_stepper.py
+++ b/extras/manual_extruder_stepper.py
@@ -39,7 +39,6 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
-        self.extruder_name = config.get('extruder', None)
         self.pressure_advance = self.pressure_advance_smooth_time = 0.
         self.config_pa = config.getfloat('pressure_advance', 0., minval=0.)
         self.config_smooth_time = config.getfloat('pressure_advance_smooth_time', 0.040, above=0., maxval=.200)
@@ -112,13 +111,6 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
                                    self.name, self.cmd_MANUAL_STEPPER,
                                    desc=self.cmd_MANUAL_STEPPER_help)
 
-
-        self.printer.register_event_handler("klippy:connect",
-                                            self.handle_connect)
-    
-    def handle_connect(self):
-        if self.extruder_name:
-            self.sync_to_extruder(self.extruder_name)
 
     def do_enable(self, enable):
         assert self.motion_queue is None

--- a/extras/manual_extruder_stepper.py
+++ b/extras/manual_extruder_stepper.py
@@ -45,10 +45,9 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
 
         # Setup stepper
         self.can_home = True
-        self.stepper = PrinterRailWithMockEndstop(config, need_position_minmax=False, default_position_endstop=0.)
-        self.steppers = self.stepper.get_steppers()
-
-        self.rail = self.stepper # For forwarding manual_stepper...
+        self.rail = PrinterRailWithMockEndstop(config, need_position_minmax=False, default_position_endstop=0.) # For forwarding manual_stepper...
+        self.steppers = self.rail.get_steppers()
+        self.stepper = self.steppers[0]
 
         self.velocity = config.getfloat('velocity', 5., above=0.)
         self.accel = self.homing_accel = config.getfloat('accel', 0., minval=0.)
@@ -104,7 +103,6 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
         gcode.register_mux_command('MANUAL_STEPPER', "STEPPER",
                                    self.name, self.cmd_MANUAL_STEPPER,
                                    desc=self.cmd_MANUAL_STEPPER_help)
-
 
     def do_enable(self, enable):
         assert self.motion_queue is None

--- a/extras/manual_extruder_stepper.py
+++ b/extras/manual_extruder_stepper.py
@@ -19,6 +19,7 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
+        self.extruder_name = config.get('extruder', None)
         self.pressure_advance = self.pressure_advance_smooth_time = 0.
         self.config_pa = config.getfloat('pressure_advance', 0., minval=0.)
         self.config_smooth_time = config.getfloat('pressure_advance_smooth_time', 0.040, above=0., maxval=.200)
@@ -89,6 +90,13 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
                                    self.name, self.cmd_MANUAL_STEPPER,
                                    desc=self.cmd_MANUAL_STEPPER_help)
 
+
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+    
+    def handle_connect(self):
+        if self.extruder_name:
+            self.sync_to_extruder(self.extruder_name)
 
     def do_enable(self, enable):
         assert self.motion_queue is None

--- a/extras/manual_extruder_stepper.py
+++ b/extras/manual_extruder_stepper.py
@@ -44,15 +44,9 @@ class ManualExtruderStepper(kinematics_extruder.ExtruderStepper, manual_stepper.
         self.config_smooth_time = config.getfloat('pressure_advance_smooth_time', 0.040, above=0., maxval=.200)
 
         # Setup stepper
-        if not self.name.startswith('extruder'):
-            self.can_home = True
-            self.stepper = PrinterRailWithMockEndstop(config, need_position_minmax=False, default_position_endstop=0.)
-            self.steppers = self.stepper.get_steppers()
-        else:
-            # if we are a toolhead extruder, can't have an endstop for now
-            self.can_home = False
-            self.stepper = stepper.PrinterStepper(config)
-            self.steppers = [self.stepper]
+        self.can_home = True
+        self.stepper = PrinterRailWithMockEndstop(config, need_position_minmax=False, default_position_endstop=0.)
+        self.steppers = self.stepper.get_steppers()
 
         self.rail = self.stepper # For forwarding manual_stepper...
 


### PR DESCRIPTION
This is my attempt at a homable extruders. The basic idea is that we leverage the just added `manual_extruder_stepper` and its `manual_homing` capability. 

~~With this PR, we will need to make more modifications to the configs. 
In particular, the printer's `[extruder]` section should no longer contain `step_pin`, `dir_pin`, `rotational_distance` etc --- these are characteristics of the toolhead stepper and they are now put in a separate `[manual_extruder_stepper extruder]` section.~~
Edit: not needed anymore with latest commit

With this change, we have enabled the following possible modes:
1. Link toolhead stepper to the extruder and set gear stepper in manual mode. This is the default mode. 
1. Link toolhead stepper to the extruder and gear stepper synced to the extruder. Here, the distinction between the toolhead stepper and the gear stepper is only that `printer.extruder.extruder_stepper = toolhead_stepper`. For both steppers, they are set to the same kinematics and trapq. This is done by the existing function `_sync_gear_to_extruder`.
1. Set toolhead stepper in manual mode and sync it to the gear stepper (also in manual mode). This is done by a new context manager function `_sync_toolhead_to_gear`. 
1. Technically, we can also do "gear stepper in manual mode and synced to the toolhead stepper (also in manual mode)", but this seem equivalent to the third mode and currently not implemented.

With the above modes enabled, we finally get to the interesting part of this PR: klipper native homing. 
With the third mode, we can now support filament homing. 
For now, this PR will focus on homing to the toolhead sensor. 
In particular, we can enter the third mode, and invoke a `manual_homing` move on the gear stepper to let the filament reach for the toolhead sensor. This native homing removes the need to advance the filament a few mms step by step, and makes homing to sensor much faster. 

In the future, we can add more homing like stallguard or homing to a MMU toolhead sensor. 