### PR TITLE
added filamentblock width parameter

### DIFF
--- a/ercf_parameters.cfg
+++ b/ercf_parameters.cfg
@@ -169,5 +169,5 @@ sync_load_speed: 10		# mm/s speed of synchronized extruder load moves
 sync_unload_speed: 10		# mm/s speed of synchronized extruder unload moves
 nozzle_load_speed: 12		# mm/s speed of load move inside extruder from homing position to meltzone
 nozzle_unload_speed: 12		# mm/s speed of unload moves inside of extruder (very initial move from meltzone is 50% of this)
-
+filamentblock_width: 21     # mm width of a single filament block. This is used for calculating maximum travel distance of the selector. Default value 21 mm for ERCF 1.1, 23mm for TripleDecky
 

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -217,6 +217,7 @@ class Ercf:
         self.sensor_to_nozzle = config.getfloat('sensor_to_nozzle', 0., minval=5.) # For toolhead sensor
         self.nozzle_load_speed = config.getfloat('nozzle_load_speed', 15, minval=1., maxval=100.)
         self.nozzle_unload_speed = config.getfloat('nozzle_unload_speed', 20, minval=1., maxval=100.)
+        self.filamentblock_width = config.getint('filamentblock_width', 21) # 21 for ERCF v1.1 default filament blocks
 
         # Gear/Extruder synchronization controls
         self.sync_to_extruder = config.getint('sync_to_extruder', 0, minval=0, maxval=1)
@@ -1449,7 +1450,7 @@ class Ercf:
         try:
             self.calibrating = True
             self._servo_up()
-            move_length = 10. + gate*21 + (gate//3)*5 + (self.bypass_offset > 0)
+            move_length = 10. + gate*self.filamentblock_width + (gate//3)*5 + (self.bypass_offset > 0)
             self._log_always("Measuring the selector position for gate %d" % gate)
             selector_steps = self.selector_stepper.steppers[0].get_step_dist()
             init_position = self.selector_stepper.get_position()[0]
@@ -2589,7 +2590,7 @@ class Ercf:
         self.gate_selected = self.TOOL_UNKNOWN
         self._servo_up()
         num_channels = len(self.selector_offsets)
-        selector_length = 10. + (num_channels-1)*21. + ((num_channels-1)//3)*5. + (self.bypass_offset > 0)
+        selector_length = 10. + (num_channels-1)*self.filamentblock_width + ((num_channels-1)//3)*5. + (self.bypass_offset > 0)
         self._log_debug("Moving up to %.1fmm to home a %d channel ERCF" % (selector_length, num_channels))
         self.toolhead.wait_moves()
         if self.sensorless_selector == 1:


### PR DESCRIPTION
Due to the transition from ERCF 1.1 to a next version with changes to filament blocks, it feels like it is necessary to be able to change the filament block width as advanced parameter, so the moonraker update can be run without reediting the ercf.py file.

I replaced the value 21 with a new variable filamentblock_width and added it to ercf_parameters and loaded it on init in ercf.py and replaced it on two places. Regarding the second replacement, I wasn't sure if this works for int and float. Currently the variable is declared as int.