### PR TITLE
Optional active servo

### DIFF
--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -184,7 +184,7 @@ class Ercf:
         self.servo_up_angle = config.getfloat('servo_up_angle')
         self.servo_down_angle = config.getfloat('servo_down_angle')
         self.servo_duration = config.getfloat('servo_duration', 0.2, minval=0.1)
-        self.active_servo_down = config.getint('active_servo_down', 0, minval=0, maxval=1)
+        self.servo_active_down = config.getint('servo_active_down', 0, minval=0, maxval=1)
         self.num_moves = config.getint('num_moves', 1, minval=1)
         self.apply_bowden_correction = config.getint('apply_bowden_correction', 0, minval=0, maxval=1)
         self.load_bowden_tolerance = config.getfloat('load_bowden_tolerance', 10., minval=1.)
@@ -1111,14 +1111,14 @@ class Ercf:
         if self.gate_selected == self.TOOL_BYPASS: return
         self._log_debug("Setting servo to down angle: %d" % (self.servo_down_angle))
         self.toolhead.wait_moves()
-        self.servo.set_value(angle=self.servo_down_angle, duration=None if self.active_servo_down else self.servo_duration)
+        self.servo.set_value(angle=self.servo_down_angle, duration=None if self.servo_active_down else self.servo_duration)
         oscillations = 2
         for i in range(oscillations):
             self.toolhead.dwell(0.05)
             self._gear_stepper_move_wait(0.5, speed=25, accel=self.gear_buzz_accel, wait=False, sync=False)
             self.toolhead.dwell(0.05)
             self._gear_stepper_move_wait(-0.5, speed=25, accel=self.gear_buzz_accel, wait=False, sync=(i == oscillations - 1))
-        if not self.active_servo_down:
+        if not self.servo_active_down:
             self.toolhead.dwell(max(0., self.servo_duration - (0.1 * oscillations)))
         self.servo_state = self.SERVO_DOWN_STATE
 

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -1117,7 +1117,8 @@ class Ercf:
             self._gear_stepper_move_wait(0.5, speed=25, accel=self.gear_buzz_accel, wait=False, sync=False)
             self.toolhead.dwell(0.05)
             self._gear_stepper_move_wait(-0.5, speed=25, accel=self.gear_buzz_accel, wait=False, sync=(i == oscillations - 1))
-        self.toolhead.dwell(max(0., self.servo_duration - (0.1 * oscillations)))
+        if self.servo_duration != float("inf"):
+            self.toolhead.dwell(max(0., self.servo_duration - (0.1 * oscillations)))
         self.servo_state = self.SERVO_DOWN_STATE
 
     def _servo_up(self):
@@ -1129,7 +1130,7 @@ class Ercf:
         self.servo_state = self.SERVO_UP_STATE
 
         # Report on spring back in filament then reset counter
-        self.toolhead.dwell(self.servo_duration)
+        self.toolhead.dwell(self.servo_duration if self.servo_duration != float("inf") else 0.2)
         self.toolhead.wait_moves()
         delta = self.encoder_sensor.get_distance() - initial_encoder_position
         if delta > 0.:

--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -184,6 +184,7 @@ class Ercf:
         self.servo_up_angle = config.getfloat('servo_up_angle')
         self.servo_down_angle = config.getfloat('servo_down_angle')
         self.servo_duration = config.getfloat('servo_duration', 0.2, minval=0.1)
+        self.active_servo_down = config.getint('active_servo_down', 0, minval=0, maxval=1)
         self.num_moves = config.getint('num_moves', 1, minval=1)
         self.apply_bowden_correction = config.getint('apply_bowden_correction', 0, minval=0, maxval=1)
         self.load_bowden_tolerance = config.getfloat('load_bowden_tolerance', 10., minval=1.)
@@ -1110,14 +1111,14 @@ class Ercf:
         if self.gate_selected == self.TOOL_BYPASS: return
         self._log_debug("Setting servo to down angle: %d" % (self.servo_down_angle))
         self.toolhead.wait_moves()
-        self.servo.set_value(angle=self.servo_down_angle, duration=self.servo_duration)
+        self.servo.set_value(angle=self.servo_down_angle, duration=None if self.active_servo_down else self.servo_duration)
         oscillations = 2
         for i in range(oscillations):
             self.toolhead.dwell(0.05)
             self._gear_stepper_move_wait(0.5, speed=25, accel=self.gear_buzz_accel, wait=False, sync=False)
             self.toolhead.dwell(0.05)
             self._gear_stepper_move_wait(-0.5, speed=25, accel=self.gear_buzz_accel, wait=False, sync=(i == oscillations - 1))
-        if self.servo_duration != float("inf"):
+        if not self.active_servo_down:
             self.toolhead.dwell(max(0., self.servo_duration - (0.1 * oscillations)))
         self.servo_state = self.SERVO_DOWN_STATE
 
@@ -1130,7 +1131,7 @@ class Ercf:
         self.servo_state = self.SERVO_UP_STATE
 
         # Report on spring back in filament then reset counter
-        self.toolhead.dwell(self.servo_duration if self.servo_duration != float("inf") else 0.2)
+        self.toolhead.dwell(self.servo_duration)
         self.toolhead.wait_moves()
         delta = self.encoder_sensor.get_distance() - initial_encoder_position
         if delta > 0.:

--- a/extras/ercf_servo.py
+++ b/extras/ercf_servo.py
@@ -107,7 +107,7 @@ class ErcfServo:
             value = self._get_pwm_from_pulse_width(width)
         else:
             value = self._get_pwm_from_angle(angle)
-        if duration not in (None, float('inf')):
+        if duration is not None:
             self._set_burst_pwm(print_time, value, duration)
         elif value != self.last_value:
             self._set_pwm(print_time, value)

--- a/extras/ercf_servo.py
+++ b/extras/ercf_servo.py
@@ -107,7 +107,7 @@ class ErcfServo:
             value = self._get_pwm_from_pulse_width(width)
         else:
             value = self._get_pwm_from_angle(angle)
-        if duration is not None:
+        if duration not in (None, float('inf')):
             self._set_burst_pwm(print_time, value, duration)
         elif value != self.last_value:
             self._set_pwm(print_time, value)


### PR DESCRIPTION
This PR adds an option to actively drive the servo when it is down. 

There is some risk of over-heating the voltage regulator on the easyBRD. But, the MG90 servo's max current is below the operating current of the voltage regulator (with a proper heat sink). 
So far with my experiments, actively driving the servo eliminates the servo release problem completely while only heating up the regulator a little bit. 

Time will tell if my servo will go bad any quicker.