### PR TITLE
ERCF_CALIBRATE_ENCODER: remove duplicate log message

### DIFF
--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -1425,7 +1425,6 @@ class Ercf:
                 self._log_always("Warning: Encoder is not detecting the expected number of counts. It is possible that reflections from some teeth are unreliable")
 
             msg = "Before calibration measured length = %.6f" % old_result
-            msg += "\nBefore calibration measured length = %.6f" % old_result
             msg += "\nResulting resolution for the encoder = %.6f" % resolution
             msg += "\nAfter calibration measured length = %.6f" % new_result
             self._log_always(msg)


### PR DESCRIPTION
The line `Before calibration measured length = %.6f` appears twice in a row in the log message.
This commit removes the second ocurrence.